### PR TITLE
Fix errors when using the "Hide tooltip border" option on Classic TBC

### DIFF
--- a/CloudyTooltipMod/CloudyTooltipMod.lua
+++ b/CloudyTooltipMod/CloudyTooltipMod.lua
@@ -45,7 +45,7 @@ local function CTipModDB_Init()
 	-- Change tooltip style --
 	CTipBackdrop = GameTooltip:GetBackdrop()
 	CTipBackdrop.insets = {left = 2, right = 2, top = 2, bottom = 2}
-	CTipEdgeSize = CTipBackdrop.edgeSize
+	CTipEdgeFile = CTipBackdrop.edgeFile
 	GameTooltipStatusBar:SetHeight(5)
 end
 
@@ -595,13 +595,9 @@ local function CTipMod_Handler()
 	end
 
 	if CTipModDB['HideBorder'] then
-		CTipBackdrop.edgeSize = 0.01
+		CTipBackdrop.edgeFile = nil
 	else
-		if CTipEdgeSize > 13 then
-			CTipBackdrop.edgeSize = 13
-		else
-			CTipBackdrop.edgeSize = CTipEdgeSize
-		end
+		CTipBackdrop.edgeFile = CTipEdgeFile
 	end
 
 	GameTooltip:SetScale(CTipModDB['TipScale'])


### PR DESCRIPTION
When Classic TBC released, the old way of hiding the tooltip border by setting it to a minuscule size started throwing errors (at least for me). Changing the edge texture to nil instead achieves the same outcome without issues.

If you have concerns about removing the code that was limiting the edge size to `13`, I'm not 100% sure why you were doing that before to be honest, but I can put it back if you'd rather keep it :)